### PR TITLE
fix(librewolf.nix): prevent activation script from failing if the dir…

### DIFF
--- a/home/mrzelee/packages/librewolf.nix
+++ b/home/mrzelee/packages/librewolf.nix
@@ -65,7 +65,7 @@
     lib.mkIf (system == "aarch64-darwin") {
     activation = {
       librewolf = lib.hm.dag.entryAfter ["writeBoundary"] ''
-        ln -s ~/Library/Application\ Support/Mozilla/NativeMessagingHosts ~/Library/Application\ Support/librewolf/NativeMessagingHosts
+        ln -s ~/Library/Application\ Support/Mozilla/NativeMessagingHosts ~/Library/Application\ Support/librewolf/NativeMessagingHosts || true
       '';
     };
   };


### PR DESCRIPTION
…ectory already exists